### PR TITLE
Fix rate_limit errata in engine config 1.0

### DIFF
--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -167,8 +167,7 @@
             {
               "type": "null"
             }
-          ],
-          "additionalProperties": false
+          ]
         },
         "analytics": {
           "type": "object",


### PR DESCRIPTION
Nit: I didn't realize that `additionalProperties` was not relevant in the context of the `oneOf` I am doing in this block.