### PR TITLE
fix: Correct oauth2 and user_info_request properties in Engine cfg 1.0

### DIFF
--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -65,7 +65,7 @@
           "description": "The authentication method to use for the OAuth request.",
           "enum": ["", "client_secret_basic", "bearer_access_token"]
         },
-        "parameters": {
+        "params": {
           "type": "object",
           "description": "The parameters to include in the OAuth request, as a map of key-value pairs."
         },
@@ -86,8 +86,8 @@
           "description": "An optional map of keys to extract from the response body. See: https://docs.arcade.dev/home/auth-providers/oauth2#jsonpath-expressions-in-response_map"
         }
       },
-      "required": ["endpoint", "parameters"],
-      "additionalProperties": false
+      "required": ["endpoint"],
+      "additionalProperties": true
     }
   },
   "type": "object",
@@ -196,6 +196,7 @@
             "oneOf": [
               {
                 "type": "object",
+                "$comment": "Add a well-known OAuth provider.",
                 "properties": {
                   "id": {
                     "type": "string",
@@ -221,6 +222,43 @@
                   "provider_id": {
                     "type": "string",
                     "description": "The known provider type ID of the auth provider, e.g. 'google'."
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "description": "The OAuth client ID of the auth provider."
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "The OAuth client secret of the auth provider."
+                  }
+                },
+                "required": ["id", "type", "provider_id", "client_id"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "$comment": "Add a custom OAuth provider.",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The unique ID of the auth provider."
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "A description of the auth provider."
+                  },
+                  "enabled": {
+                    "description": "Whether the auth provider is enabled.",
+                    "oneOf": [
+                      { "type": "boolean", "default": true },
+                      { "$ref": "#/$defs/envVarPattern" },
+                      { "$ref": "#/$defs/filePattern" }
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["oauth2"],
+                    "description": "The type of the auth provider."
                   },
                   "client_id": {
                     "type": "string",
@@ -261,130 +299,29 @@
                       },
                       "user_info_request": {
                         "allOf": [
-                          { "$ref": "#/$defs/oauthRequestConfig" },
+                          {
+                            "$ref": "#/$defs/oauthRequestConfig"
+                          },
                           {
                             "type": "object",
                             "properties": {
                               "triggers": {
                                 "type": "object",
-                                "description": "Configures the triggers for the user info request.",
                                 "properties": {
                                   "on_token_grant": {
-                                    "type": "boolean",
-                                    "description": "Whether to make the user info request when a new token is granted."
+                                    "type": "boolean"
                                   },
                                   "on_token_refresh": {
-                                    "type": "boolean",
-                                    "description": "Whether to make the user info request when an existing token is refreshed."
+                                    "type": "boolean"
                                   }
                                 },
-                                "required": [
-                                  "on_token_grant",
-                                  "on_token_refresh"
-                                ],
+                                "minProperties": 1,
                                 "additionalProperties": false
                               }
                             },
-                            "additionalProperties": false
+                            "required": ["triggers"]
                           }
-                        ]
-                      }
-                    },
-                    "required": ["authorize_request", "token_request"],
-                    "additionalProperties": false
-                  }
-                },
-                "required": ["id", "type", "client_id"],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "description": "The unique ID of the auth provider."
-                  },
-                  "description": {
-                    "type": "string",
-                    "description": "A description of the auth provider."
-                  },
-                  "enabled": {
-                    "description": "Whether the auth provider is enabled.",
-                    "oneOf": [
-                      { "type": "boolean", "default": true },
-                      { "$ref": "#/$defs/envVarPattern" },
-                      { "$ref": "#/$defs/filePattern" }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": ["oauth2"],
-                    "description": "The type of the auth provider."
-                  },
-                  "client_id": {
-                    "type": "string",
-                    "description": "The OAuth client ID of the auth provider."
-                  },
-                  "client_secret": {
-                    "type": "string",
-                    "description": "The OAuth client secret of the auth provider."
-                  },
-                  "oauth2": {
-                    "type": "object",
-                    "properties": {
-                      "scope_delimiter": {
-                        "type": "string",
-                        "description": "The delimiter to use between scope values in the OAuth scope parameter.",
-                        "default": " "
-                      },
-                      "pkce": {
-                        "type": "object",
-                        "description": "Configures PKCE for the OAuth provider, if applicable. Leave blank to disable.",
-                        "properties": {
-                          "enabled": { "type": "boolean" },
-                          "code_challenge_method": {
-                            "type": "string",
-                            "description": "The method to use for generating the PKCE code challenge.",
-                            "enum": ["S256"]
-                          }
-                        },
-                        "required": ["enabled"],
-                        "additionalProperties": false
-                      },
-                      "authorize_request": {
-                        "$ref": "#/$defs/oauthRequestConfig"
-                      },
-                      "token_request": { "$ref": "#/$defs/oauthRequestConfig" },
-                      "refresh_request": {
-                        "$ref": "#/$defs/oauthRequestConfig"
-                      },
-                      "user_info_request": {
-                        "type": "object",
-                        "properties": {
-                          "endpoint": { "type": "string" },
-                          "method": {
-                            "type": "string",
-                            "enum": ["GET", "POST"]
-                          },
-                          "auth_method": { "type": "string" },
-                          "parameters": { "type": "object" },
-                          "request_content_type": { "type": "string" },
-                          "response_content_type": { "type": "string" },
-                          "response_map": {
-                            "type": "object",
-                            "additionalProperties": { "type": "string" }
-                          },
-                          "triggers": {
-                            "type": "object",
-                            "properties": {
-                              "on_token_grant": { "type": "boolean" },
-                              "on_token_refresh": { "type": "boolean" }
-                            },
-                            "required": ["on_token_grant", "on_token_refresh"],
-                            "additionalProperties": false
-                          }
-                        },
-                        "required": ["triggers"],
+                        ],
                         "additionalProperties": true
                       }
                     },

--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -196,7 +196,7 @@
             "oneOf": [
               {
                 "type": "object",
-                "$comment": "Add a well-known OAuth provider.",
+                "$comment": "Config for a well-known OAuth provider.",
                 "properties": {
                   "id": {
                     "type": "string",
@@ -237,7 +237,7 @@
               },
               {
                 "type": "object",
-                "$comment": "Add a custom OAuth provider.",
+                "$comment": "Config for a custom OAuth provider.",
                 "properties": {
                   "id": {
                     "type": "string",


### PR DESCRIPTION
Corrects some errata:
- Corrects a typo: `oauth2.{request_type}.parameters` is actually `params`
- Removes an extraneous `oauth2` property in the well-known provider config path
- De-dupes `user_info_request` since almost all of its properties are actually in `/#defs/oauthRequestConfig`

I've confirmed that our shipped and documented schemas already conform to these updates. ✅ 