### PR TITLE
additional properties valid on oauth2 provider config

### DIFF
--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -326,7 +326,7 @@
                       }
                     },
                     "required": ["authorize_request", "token_request"],
-                    "additionalProperties": false
+                    "additionalProperties": true
                   }
                 },
                 "required": ["id", "type", "client_id", "oauth2"],


### PR DESCRIPTION
We can parse the [Extras](https://github.com/ArcadeAI/Engine/blob/c476921ab767cd70b0f2cc2e26f1be91631e32b7/pkg/auth/config.go#L39) without a problem. This also lets us add properties when needed that we are not ready to document.