### PR TITLE
fix: Allow additional props in api, workers

### DIFF
--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -185,7 +185,7 @@
           "additionalProperties": true
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "auth": {
       "type": "object",
@@ -634,8 +634,8 @@
                       "additionalProperties": false
                     }
                   },
-                  "required": ["id", "enabled", "http"],
-                  "additionalProperties": false
+                  "required": ["id", "enabled"],
+                  "additionalProperties": true
                 }
               }
             },


### PR DESCRIPTION
Allows additional properties in the `api` section, and also in `tools.directors[].workers` blocks, to allow for upcoming features to be tested in advance.