### PR TITLE
Remove analytics from schema

### DIFF
--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -170,19 +170,6 @@
               "type": "null"
             }
           ]
-        },
-        "analytics": {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "oneOf": [
-                { "type": "boolean", "default": false },
-                { "$ref": "#/$defs/envVarPattern" },
-                { "$ref": "#/$defs/filePattern" }
-              ]
-            }
-          },
-          "additionalProperties": true
         }
       },
       "additionalProperties": true


### PR DESCRIPTION
Removes in keeping with recent engine changes. We require alternate means to opt-out of product analytics with the new usage service.