### PR TITLE
add toolkit types

### DIFF
--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -638,11 +638,13 @@
         "default_toolkit_type": {
           "type": "string",
           "enum": ["standard", "convenience", "premium"],
-          "description": "The default toolkit type to use for tool calls."
+          "description": "DEPRECATED: The default toolkit type to use for tool calls.",
+          "deprecated": true
         },
         "toolkits": {
           "type": "array",
-          "description": "A list of toolkit configurations.",
+          "description": "DEPRECATED: A list of toolkit configurations.",
+          "deprecated": true,
           "items": {
             "type": "object",
             "properties": {

--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -671,7 +671,7 @@
           "additionalProperties": false
         }
       },
-      "required": ["directors", "default_toolkit_type"],
+      "required": ["directors"],
       "additionalProperties": false
     }
   },

--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -634,9 +634,42 @@
             "required": ["id", "workers"],
             "additionalProperties": true
           }
+        },
+        "default_toolkit_type": {
+          "type": "string",
+          "enum": ["standard", "convenience", "premium"],
+          "description": "The default toolkit type to use for tool calls."
+        },
+        "toolkits": {
+          "type": "array",
+          "description": "A list of toolkit configurations.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "The unique ID of the toolkit."
+              },
+              "type": {
+                "type": "string",
+                "enum": ["standard", "convenience", "premium"],
+                "description": "The type of the toolkit."
+              },
+              "aliases": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Aliases for the toolkit."
+              }
+            },
+            "required": ["id", "type"],
+            "additionalProperties": false
+          },
+          "additionalProperties": false
         }
       },
-      "required": ["directors"],
+      "required": ["directors", "default_toolkit_type"],
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
Example for the tools section that works:

```yaml
tools:
  directors:
    - id: default
      enabled: true
      max_tools: 64
      workers:
        - id: local_worker
          enabled: true
          http:
            uri: 'http://localhost:8002'
            timeout: 30
            retry: 3
            secret: ${env:ARCADE_WORKER_SECRET} # If not set, defaults to 'dev' in development mode only
        - id: mcp_demo
          enabled: true
          mcp:
            uri: 'https://mcp-http-demo.arcade.dev/mcp'
            timeout: 30
            retry: 3

  default_toolkit_type: standard

  toolkits:
    - id: firecrawl
      aliases:
        - arcade_firecrawl
      type: convenience
    - id: e2b
      aliases:
        - arcade_e2b
      type: convenience
    - id: serpapi
      aliases:
        - arcade_serpapi
      type: convenience
```