### PR TITLE
Remove unsupported deprecated tags

### DIFF
--- a/engine/config/1.0/example.yaml
+++ b/engine/config/1.0/example.yaml
@@ -172,16 +172,3 @@ tools:
             timeout: 30
             retry: 3
             secret: ${env:ARCADE_WORKER_SECRET}
-  toolkits:
-    - id: firecrawl
-      type: premium
-      aliases:
-        - arcade_firecrawl
-    - id: e2b
-      type: premium
-      aliases:
-        - arcade_e2b
-    - id: serpapi
-      type: premium
-      aliases:
-        - arcade_serpapi

--- a/engine/config/1.0/example.yaml
+++ b/engine/config/1.0/example.yaml
@@ -1,0 +1,187 @@
+# yaml-language-server: $schema=schema.json
+$schema: schema.json
+
+api:
+  development: ${env:API_DEVELOPMENT}
+  host: ${env:ARCADE_API_HOST}
+  port: ${env:ARCADE_API_PORT}
+
+
+auth:
+  providers:
+    - id: default-atlassian
+      description: 'The default Atlassian provider'
+      enabled: false
+      type: oauth2
+      provider_id: atlassian
+      client_id: ${env:ATLASSIAN_CLIENT_ID}
+      client_secret: ${env:ATLASSIAN_CLIENT_SECRET}
+
+    - id: default-discord
+      description: 'The default Discord provider'
+      enabled: false
+      type: oauth2
+      provider_id: discord
+      client_id: ${env:DISCORD_CLIENT_ID}
+      client_secret: ${env:DISCORD_CLIENT_SECRET}
+
+    - id: default-dropbox
+      description: 'The default Dropbox provider'
+      enabled: false
+      type: oauth2
+      provider_id: dropbox
+      client_id: ${env:DROPBOX_CLIENT_ID}
+      client_secret: ${env:DROPBOX_CLIENT_SECRET}
+
+    - id: default-github
+      description: 'The default GitHub provider'
+      enabled: false
+      type: oauth2
+      provider_id: github
+      client_id: ${env:GITHUB_CLIENT_ID}
+      client_secret: ${env:GITHUB_CLIENT_SECRET}
+
+    - id: default-google
+      description: 'The default Google provider'
+      enabled: false
+      type: oauth2
+      provider_id: google
+      client_id: ${env:GOOGLE_CLIENT_ID}
+      client_secret: ${env:GOOGLE_CLIENT_SECRET}
+
+    - id: default-linkedin
+      description: 'The default LinkedIn provider'
+      enabled: false
+      type: oauth2
+      provider_id: linkedin
+      client_id: ${env:LINKEDIN_CLIENT_ID}
+      client_secret: ${env:LINKEDIN_CLIENT_SECRET}
+
+    - id: default-microsoft
+      description: 'The default Microsoft provider'
+      enabled: false
+      type: oauth2
+      provider_id: microsoft
+      client_id: ${env:MICROSOFT_CLIENT_ID}
+      client_secret: ${env:MICROSOFT_CLIENT_SECRET}
+
+    - id: default-reddit
+      description: 'The default Reddit provider'
+      enabled: false
+      type: oauth2
+      provider_id: reddit
+      client_id: ${env:REDDIT_CLIENT_ID}
+      client_secret: ${env:REDDIT_CLIENT_SECRET}
+
+    - id: default-slack
+      description: 'The default Slack provider'
+      enabled: false
+      type: oauth2
+      provider_id: slack
+      client_id: ${env:SLACK_CLIENT_ID}
+      client_secret: ${env:SLACK_CLIENT_SECRET}
+
+    - id: default-spotify
+      description: 'The default Spotify provider'
+      enabled: false
+      type: oauth2
+      provider_id: spotify
+      client_id: ${env:SPOTIFY_CLIENT_ID}
+      client_secret: ${env:SPOTIFY_CLIENT_SECRET}
+
+    - id: default-twitch
+      description: 'The default Twitch provider'
+      enabled: false
+      type: oauth2
+      provider_id: twitch
+      client_id: ${env:TWITCH_CLIENT_ID}
+      client_secret: ${env:TWITCH_CLIENT_SECRET}
+
+    - id: default-x
+      description: 'The default X provider'
+      enabled: false
+      type: oauth2
+      provider_id: x
+      client_id: ${env:X_CLIENT_ID}
+      client_secret: ${env:X_CLIENT_SECRET}
+
+    - id: default-zoom
+      description: 'The default Zoom provider'
+      enabled: false
+      type: oauth2
+      provider_id: zoom
+      client_id: ${env:ZOOM_CLIENT_ID}
+      client_secret: ${env:ZOOM_CLIENT_SECRET}
+
+
+llm:
+  models:
+    - id: my-openai-model-provider
+      openai:
+        api_key: ${env:OPENAI_API_KEY}
+    #- id: my-anthropic-model-provider
+    #  anthropic:
+    #    api_key: ${env:ANTHROPIC_API_KEY}
+    # - id: my-ollama-model-provider
+    #   openai:
+    #     base_url: http://localhost:11434
+    #     chat_endpoint: /v1/chat/completions
+    #     model: llama3.2
+    #     api_key: ollama
+    #- id: my-groq-model-provider
+    #  openai:
+    #    base_url: 'https://api.groq.com/openai/v1'
+    #    api_key: ${env:GROQ_API_KEY}
+
+
+security:
+  root_keys:
+    - id: key1
+      default: true
+      value: ${env:ROOT_KEY_1}
+
+
+storage:
+  postgres:
+    user: ${env:POSTGRES_USER}
+    password: ${env:POSTGRES_PASSWORD}
+    host: ${env:POSTGRES_HOST}
+    port: ${env:POSTGRES_PORT}
+    db: ${env:POSTGRES_DB}
+    sslmode: require
+
+
+telemetry:
+  environment: ${env:TELEMETRY_ENVIRONMENT}
+  logging:
+    # debug, info, warn, error
+    level: ${env:TELEMETRY_LOGGING_LEVEL}
+    encoding: ${env:TELEMETRY_LOGGING_ENCODING}
+
+
+tools:
+  directors:
+    - id: default
+      enabled: true
+      max_tools: 64
+      workers:
+        - id: worker
+          enabled: true
+          http:
+            uri: ${env:ARCADE_WORKER_URI}
+            timeout: 30
+            retry: 3
+            secret: ${env:ARCADE_WORKER_SECRET}
+  toolkits:
+    - id: firecrawl
+      type: premium
+      aliases:
+        - arcade_firecrawl
+    - id: e2b
+      type: premium
+      aliases:
+        - arcade_e2b
+    - id: serpapi
+      type: premium
+      aliases:
+        - arcade_serpapi

--- a/engine/config/1.0/example.yaml
+++ b/engine/config/1.0/example.yaml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=schema.json
-$schema: schema.json
+# yaml-language-server: $schema=./schema.json
+$schema: ./engine/config/1.0/schema.json
 
 api:
   development: ${env:API_DEVELOPMENT}

--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -638,13 +638,11 @@
         "default_toolkit_type": {
           "type": "string",
           "enum": ["standard", "convenience", "premium"],
-          "description": "DEPRECATED: The default toolkit type to use for tool calls.",
-          "deprecated": true
+          "description": "DEPRECATED: The default toolkit type to use for tool calls."
         },
         "toolkits": {
           "type": "array",
           "description": "DEPRECATED: A list of toolkit configurations.",
-          "deprecated": true,
           "items": {
             "type": "object",
             "properties": {

--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -634,43 +634,10 @@
             "required": ["id", "workers"],
             "additionalProperties": true
           }
-        },
-        "default_toolkit_type": {
-          "type": "string",
-          "enum": ["standard", "convenience", "premium"],
-          "description": "DEPRECATED: The default toolkit type to use for tool calls."
-        },
-        "toolkits": {
-          "type": "array",
-          "description": "DEPRECATED: A list of toolkit configurations.",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The unique ID of the toolkit."
-              },
-              "type": {
-                "type": "string",
-                "enum": ["standard", "convenience", "premium"],
-                "description": "The type of the toolkit."
-              },
-              "aliases": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "Aliases for the toolkit."
-              }
-            },
-            "required": ["id", "type"],
-            "additionalProperties": false
-          },
-          "additionalProperties": false
         }
       },
       "required": ["directors"],
-      "additionalProperties": false
+      "additionalProperties": true
     }
   },
   "required": ["api", "llm", "security", "storage", "telemetry", "tools"],


### PR DESCRIPTION
apparently, our validator doesn't like the `deprecated` tag. Still keeping it in the descriptions:

```text
Run cardinalby/schema-validator-action@v3
Contents of 'engine.dev.yaml' has been parsed as yaml object
"Trying to find 'https://raw.githubusercontent.com/ArcadeAI/schemas/main/engine/config/1.0/schema.json' schema from $schema property of the file...
Schema loaded from https://raw.githubusercontent.com/ArcadeAI/schemas/main/engine/config/1.0/schema.json has undefined type:
Contents of 'https://raw.githubusercontent.com/ArcadeAI/schemas/main/engine/config/1.0/schema.json' has been parsed as json object
Error: Unexpected rules in type "array" at #/properties/tools/properties/toolkits
Error: Failed because of schema error
```