### PR TITLE
Remove environment as required so that env vars can be source of truth.

### DIFF
--- a/engine/config/1.0/example.yaml
+++ b/engine/config/1.0/example.yaml
@@ -152,7 +152,6 @@ storage:
 
 
 telemetry:
-  environment: ${env:TELEMETRY_ENVIRONMENT}
   logging:
     # debug, info, warn, error
     level: ${env:TELEMETRY_LOGGING_LEVEL}

--- a/engine/config/1.0/schema.json
+++ b/engine/config/1.0/schema.json
@@ -528,7 +528,7 @@
       "properties": {
         "environment": {
           "type": "string",
-          "description": "The environment the Arcade Engine is running in."
+          "description": "The environment the Arcade Engine is running in; overrides the environment variables."
         },
         "logging": {
           "type": "object",
@@ -548,7 +548,7 @@
           "additionalProperties": false
         }
       },
-      "required": ["environment", "logging"],
+      "required": ["logging"],
       "additionalProperties": true
     },
     "tools": {


### PR DESCRIPTION
Engine uses the config as the source of truth, instead of env vars being able to override the config.