### PR TITLE
fix: remove description siblings from $ref fields

### DIFF
--- a/logic_extensions/http/1.0/schema.yaml
+++ b/logic_extensions/http/1.0/schema.yaml
@@ -5,7 +5,7 @@ info:
     Webhook contract between Arcade Engine and external hook servers for tool execution control.
 
     **Note:** All endpoint paths are fully configurable. The paths shown (/pre, /post, etc.) are just defaults. You specify the actual paths when configuring your hooks in Arcade. The payloads described below remain the same.
-  version: 1.1.0-beta
+  version: 1.1.1-beta
 
 paths:
   /pre:

--- a/logic_extensions/http/1.0/schema.yaml
+++ b/logic_extensions/http/1.0/schema.yaml
@@ -186,7 +186,6 @@ components:
           description: Tool version
         metadata:
           $ref: '#/components/schemas/ToolVersionInfoMetadata'
-          description: Tool metadata
 
     OAuth2Details:
       type: object
@@ -395,7 +394,6 @@ components:
           description: Tool version
         metadata:
           $ref: '#/components/schemas/ToolVersionInfoMetadata'
-          description: Tool metadata
 
     ToolVersionInfoMetadata:
       type: object


### PR DESCRIPTION
## Summary

- Remove `description` siblings from `$ref` fields on `ToolInfo.metadata` and `ToolVersionInfo.metadata`
- oapi-codegen v2.6.0 silently drops `$ref` properties that have `description` siblings, causing `ToolInfo.metadata` to be missing from generated Go code
- In OpenAPI 3.0.x, sibling keywords next to `$ref` are ignored per spec, so these descriptions had no effect anyway

## Context

Follow-up to #26. Discovered during Go codegen in [ArcadeAI/monorepo#517](https://github.com/ArcadeAI/monorepo/pull/517).

Made with [Cursor](https://cursor.com)